### PR TITLE
Support direct calls to the analyzer

### DIFF
--- a/src/analyze_api.jl
+++ b/src/analyze_api.jl
@@ -22,6 +22,9 @@ end
 function analyze(input::AbstractArray{<:Real}, method::AbstractXAIMethod; kwargs...)
     return method(input, MaxActivationNS(); kwargs...)
 end
+function (method::AbstractXAIMethod)(input::AbstractArray{<:Real}; kwargs...)
+    return method(input, MaxActivationNS(); kwargs...)
+end
 
 # Explanations and outputs are returned in a wrapper.
 # Metadata such as the analyzer allows dispatching on functions like `heatmap`.

--- a/src/lrp.jl
+++ b/src/lrp.jl
@@ -42,6 +42,7 @@ function LRP(model::Chain, r::AbstractLRPRule; kwargs...)
     return LRP(model, rules; kwargs...)
 end
 # Additional constructors for convenience:
+LRP(model::Chain; kwargs...) = LRP(model, ZeroRule(); kwargs...)
 LRPZero(model::Chain; kwargs...) = LRP(model, ZeroRule(); kwargs...)
 LRPEpsilon(model::Chain; kwargs...) = LRP(model, EpsilonRule(); kwargs...)
 LRPGamma(model::Chain; kwargs...) = LRP(model, GammaRule(); kwargs...)

--- a/test/test_vgg11.jl
+++ b/test/test_vgg11.jl
@@ -75,3 +75,9 @@ end
 @testset "Layerwise relevances" begin
     test_vgg11("LRPZero", LRPZero; layerwise_relevances=true)
 end
+
+# Test LRP constructor with no rules
+a1 = LRP(model)
+a2 = LRPZero(model)
+@test a1.model == a2.model
+@test a1.rules == a2.rules

--- a/test/test_vgg11.jl
+++ b/test/test_vgg11.jl
@@ -28,14 +28,19 @@ end
 function test_vgg11(name, method; kwargs...)
     analyzer = method(model)
     @testset "$name" begin
+        # Reference test attribution
         print("Timing $name...\t")
         @time expl = analyze(img, analyzer; kwargs...)
         attr = expl.attribution
-
         @test size(attr) == size(img)
         @test_reference "references/vgg11/$(name).jld2" Dict("expl" => attr) by =
             (r, a) -> isapprox(r["expl"], a["expl"]; rtol=0.05)
 
+        # Test direct call of analyzer
+        expl2 = analyzer(img; kwargs...)
+        @test expl.attribution ≈ expl2.attribution
+
+        # Test direct call of heatmap
         h1 = heatmap(expl)
         h2 = heatmap(img, analyzer; kwargs...)
         @test h1 ≈ h2


### PR DESCRIPTION
Instead of writing
```julia
analyze(input, analyzer; kwargs...)
```
it is now also possible to do
```julia
analyzer(input; kwargs...)
```