### PR TITLE
Fast `WSquareRule` on Dense layers

### DIFF
--- a/src/lrp/rules.jl
+++ b/src/lrp/rules.jl
@@ -452,3 +452,8 @@ function lrp!(Rₖ, ::FlatRule, layer::Dense, aₖ, Rₖ₊₁)
     end
     return nothing
 end
+function lrp!(Rₖ, ::WSquareRule, layer::Dense, aₖ, Rₖ₊₁)
+    den = sum(layer.weight .^ 2; dims=2)
+    @tullio Rₖ[j, b] = layer.weight[i, j]^2 / den[i] * Rₖ₊₁[i, b]
+    return nothing
+end


### PR DESCRIPTION
This provides a ~2.5 speedup in local benchmarks:
```
                                   ID                 time ratio               memory ratio
  ––––––––––––––––––––––––––––––––––– –––––––––––––––––––––––––– ––––––––––––––––––––––––––
    ["Layer", "Dense", "WSquareRule"] 0.38 (5%) :whitecheckmark: 0.98 (1%) :whitecheckmark:
```