### PR TITLE
Pre-allocate modified layers for LRP

### DIFF
--- a/src/ExplainableAI.jl
+++ b/src/ExplainableAI.jl
@@ -48,9 +48,6 @@ export AbstractLRPRule
 export LRP_CONFIG
 export ZeroRule, EpsilonRule, GammaRule, WSquareRule, FlatRule, PassRule
 export ZBoxRule, ZPlusRule, AlphaBetaRule
-export modify_input, modify_denominator
-export modify_param!, modify_layer!
-export check_compat
 
 # LRP composites
 export Composite, AbstractCompositePrimitive

--- a/src/flux_utils.jl
+++ b/src/flux_utils.jl
@@ -67,20 +67,11 @@ function strip_softmax(model::Chain)
     end
     return model
 end
-strip_softmax(l::Dense) = Dense(l.weight, l.bias, identity)
-function strip_softmax(l::Conv)
-    return Conv(identity, l.weight, l.bias, l.stride, l.pad, l.dilation, l.groups)
-end
+strip_softmax(l) = copy_layer(l, l.weight, l.bias; σ=identity)
 
-has_weight_and_bias(layer) = hasproperty(layer, :weight) && hasproperty(layer, :bias)
-function require_weight_and_bias(rule, layer)
-    !has_weight_and_bias(layer) && throw(
-        ArgumentError(
-            "$rule requires linear layer with weight and bias parameters, got $layer."
-        ),
-    )
-    return nothing
-end
+has_weight(layer) = hasproperty(layer, :weight)
+has_bias(layer) = hasproperty(layer, :bias)
+has_weight_and_bias(layer) = has_weight(layer) && has_bias(layer)
 
 """
     copy_layer(layer, W, b, [σ=identity])

--- a/src/lrp/lrp.jl
+++ b/src/lrp/lrp.jl
@@ -14,43 +14,43 @@ or by passing a composite, see [`Composite`](@ref) for an example.
 [1] G. Montavon et al., Layer-Wise Relevance Propagation: An Overview
 [2] W. Samek et al., Explaining Deep Neural Networks and Beyond: A Review of Methods and Applications
 """
-struct LRP{R<:AbstractVector{<:AbstractLRPRule}} <: AbstractXAIMethod
+struct LRP{R<:AbstractVector{<:Tuple}} <: AbstractXAIMethod
     model::Chain
-    rules::R
+    state::R  # each entry is a tuple `(rule, modified_layer)`
+end
+rules(analyzer::LRP) = map(first, analyzer.state)
+modified_layers(analyzer::LRP) = map(last, analyzer.state)
 
-    # Construct LRP analyzer by manually assigning a rule to each layer
-    function LRP(
-        model::Chain,
-        rules::AbstractVector{<:AbstractLRPRule};
-        skip_checks=false,
-        verbose=true,
-    )
-        model = flatten_model(model)
-        if !skip_checks
-            check_output_softmax(model)
-            check_model(Val(:LRP), model; verbose=verbose)
-        end
-        if length(model.layers) != length(rules)
-            throw(ArgumentError("Length of rules doesn't match length of Flux chain."))
-        end
-        return new{typeof(rules)}(model, rules)
+# Construct rule_layer_tuples from model and array of rules
+function LRP(
+    model::Chain,
+    rules::AbstractVector{<:AbstractLRPRule};
+    is_flat=false,
+    skip_checks=false,
+    verbose=true,
+)
+    !is_flat && (model = flatten_model(model))
+    if !skip_checks
+        check_output_softmax(model)
+        check_model(Val(:LRP), model; verbose=verbose)
     end
+
+    state = map(zip(rules, model.layers)) do (r, l)
+        !is_compatible(r, l) && throw(LRPCompatibilityError(r, l))
+        return (r, modify_layer(r, l))
+    end
+    return LRP(model, state)
 end
 
-# Construct LRP composite
-function LRP(model::Chain, comp::Composite; kwargs...)
-    model = flatten_model(model)
-    rules = comp(model)
-    return LRP(model, rules; kwargs...)
+# Construct vector of rules by applying composite
+function LRP(model::Chain, composite::Composite; is_flat=false, kwargs...)
+    !is_flat && (model = flatten_model(model))
+    rules = composite(model)
+    return LRP(model, rules; is_flat=true, kwargs...)
 end
-# Construct LRP analyzer by assigning a single rule to all layers
-function LRP(model::Chain, r::AbstractLRPRule; kwargs...)
-    model = flatten_model(model)
-    rules = repeat([r], length(model.layers))
-    return LRP(model, rules; kwargs...)
-end
-# Additional constructors for convenience: use ZeroRule everywhere
-LRP(model::Chain; kwargs...) = LRP(model, ZeroRule(); kwargs...)
+
+# Convenience constructor: use ZeroRule everywhere
+LRP(model::Chain; kwargs...) = LRP(model, Composite(ZeroRule()); kwargs...)
 
 # The call to the LRP analyzer.
 function (analyzer::LRP)(
@@ -69,8 +69,8 @@ function (analyzer::LRP)(
     rels[end][output_indices] = acts[end][output_indices]
 
     # Backward pass through layers, applying LRP rules
-    for (i, rule) in Iterators.reverse(enumerate(analyzer.rules))
-        lrp!(rels[i], rule, layers[i], acts[i], rels[i + 1]) # inplace update rels[i]
+    for (i, (rule, modified_layer)) in Iterators.reverse(enumerate(analyzer.state))
+        lrp!(rels[i], rule, modified_layer, acts[i], rels[i + 1]) # inplace update rels[i]
     end
 
     return Explanation(

--- a/src/lrp/show.jl
+++ b/src/lrp/show.jl
@@ -12,10 +12,11 @@ typename(x) = string(nameof(typeof(x)))
 _print_layer(io::IO, l) = string(sprint(show, l; context=io))
 function Base.show(io::IO, m::MIME"text/plain", analyzer::LRP)
     layer_names = [_print_layer(io, l) for l in analyzer.model]
+    rs = rules(analyzer)
     npad = maximum(length.(layer_names)) + 1 # padding to align rules with rpad
 
     println(io, "LRP", "(")
-    for (l, r) in zip(layer_names, analyzer.rules)
+    for (r, l) in zip(rs, layer_names)
         print(io, "  ", rpad(l, npad), " => ")
         printstyled(io, r; color=COLOR_RULE)
         println(io, ",")

--- a/test/test_composite.jl
+++ b/test/test_composite.jl
@@ -1,4 +1,5 @@
 using ExplainableAI
+using ExplainableAI: rules
 using Flux
 
 # Load VGG model:
@@ -39,7 +40,7 @@ composite1 = Composite(
 )
 
 analyzer1 = LRP(model, composite1)
-@test analyzer1.rules == [
+@test rules(analyzer1) == [
     ZBoxRule(-3.0f0, 3.0f0)
     EpsilonRule(1.0f-6)
     FlatRule()
@@ -80,7 +81,7 @@ composite2 = Composite(
     ),
 )
 analyzer2 = LRP(model, composite2)
-@test analyzer2.rules == [
+@test rules(analyzer2) == [
     AlphaBetaRule(2.0f0, 1.0f0)
     ZeroRule()
     ZeroRule()

--- a/test/test_rules.jl
+++ b/test/test_rules.jl
@@ -1,7 +1,8 @@
 using LoopVectorization
 using ExplainableAI
-using ExplainableAI: modify_param!, modify_bias!, has_weight_and_bias
-import ExplainableAI: lrp!, modify_layer!, get_layer_resetter
+using ExplainableAI: lrp!, has_weight_and_bias
+using ExplainableAI: modify_input, modify_denominator, is_compatible
+using ExplainableAI: modify_parameters, modify_weight, modify_bias, modify_layer
 using Flux
 using LinearAlgebra: I
 using ReferenceTests
@@ -64,11 +65,19 @@ end
     Rₖ_α2β1 = [-2.0f0, 0.5f0]
 
     R̂ₖ = similar(aₖ) # will be inplace updated
-    @inferred lrp!(R̂ₖ, AlphaBetaRule(1.0f0, 0.0f0), layer, aₖ, Rₖ₊₁)
+    rule = AlphaBetaRule(1.0f0, 0.0f0)
+    modified_layers = modify_layer(rule, layer)
+    @inferred lrp!(R̂ₖ, rule, modified_layers, aₖ, Rₖ₊₁)
     @test R̂ₖ ≈ Rₖ_α1β0
-    @inferred lrp!(R̂ₖ, AlphaBetaRule(2.0f0, 1.0f0), layer, aₖ, Rₖ₊₁)
+
+    rule = AlphaBetaRule(2.0f0, 1.0f0)
+    modified_layers = modify_layer(rule, layer)
+    @inferred lrp!(R̂ₖ, rule, modified_layers, aₖ, Rₖ₊₁)
     @test R̂ₖ ≈ Rₖ_α2β1
-    @inferred lrp!(R̂ₖ, ZPlusRule(), layer, aₖ, Rₖ₊₁) # equivalent to α=1, β=0
+
+    rule = ZPlusRule()
+    modified_layers = modify_layer(rule, layer)
+    @inferred lrp!(R̂ₖ, rule, modified_layers, aₖ, Rₖ₊₁)
     @test R̂ₖ ≈ Rₖ_α1β0
 end
 
@@ -77,48 +86,35 @@ T = Float32
 pseudorandn(dims...) = randn(MersenneTwister(123), T, dims...)
 
 ## Test individual rules
-@testset "modify_param" begin
+@testset "modify_parameters" begin
     rule = GammaRule(0.42)
     W, b = [1.0 -1.0; 2.0 0.0], [-1.0, 1.0]
     layer = Dense(W, b, relu)
-    reset! = get_layer_resetter(rule, layer)
 
-    modify_layer!(rule, layer; ignore_bias=true)
-    @test layer.weight ≈ [1.42 -1.0; 2.84 0.0]
-    @test layer.bias ≈ b
-    reset!()
+    modified_layer = @inferred modify_layer(rule, layer)
+    @test modified_layer.weight ≈ [1.42 -1.0; 2.84 0.0]
+    @test modified_layer.bias ≈ [-1.0, 1.42]
     @test layer.weight ≈ W
     @test layer.bias ≈ b
 
-    modify_layer!(rule, layer)
-    @test layer.weight ≈ [1.42 -1.0; 2.84 0.0]
-    @test layer.bias ≈ [-1.0, 1.42]
-    reset!()
-    @test layer.weight ≈ W
-    @test layer.bias ≈ b
+    modified_layer = @inferred modify_layer(Val(:keep_positive), layer)
+    @test modified_layer.weight ≈ [1.0 0.0; 2.0 0.0]
+    @test modified_layer.bias ≈ [0.0, 1.0]
 
-    modify_layer!(Val(:keep_positive), layer)
-    @test layer.weight ≈ [1.0 0.0; 2.0 0.0]
-    @test layer.bias ≈ [0.0, 1.0]
-    reset!()
+    modified_layer = @inferred modify_layer(Val(:keep_positive_zero_bias), layer)
+    @test modified_layer.weight ≈ [1.0 0.0; 2.0 0.0]
+    @test modified_layer.bias ≈ [0.0, 0.0]
 
-    modify_layer!(Val(:keep_positive_zero_bias), layer)
-    @test layer.weight ≈ [1.0 0.0; 2.0 0.0]
-    @test layer.bias ≈ [0.0, 0.0]
-    reset!()
+    modified_layer = @inferred modify_layer(Val(:keep_negative), layer)
+    @test modified_layer.weight ≈ [0.0 -1.0; 0.0 0.0]
+    @test modified_layer.bias ≈ [-1.0, 0.0]
 
-    modify_layer!(Val(:keep_negative), layer)
-    @test layer.weight ≈ [0.0 -1.0; 0.0 0.0]
-    @test layer.bias ≈ [-1.0, 0.0]
-    reset!()
+    modified_layer = @inferred modify_layer(Val(:keep_negative_zero_bias), layer)
+    @test modified_layer.weight ≈ [0.0 -1.0; 0.0 0.0]
+    @test modified_layer.bias ≈ [0.0, 0.0]
 
-    modify_layer!(Val(:keep_negative_zero_bias), layer)
-    @test layer.weight ≈ [0.0 -1.0; 0.0 0.0]
-    @test layer.bias ≈ [0.0, 0.0]
-    reset!()
-
-    @inferred modify_param!(rule, W)
-    @inferred modify_bias!(rule, b)
+    W = @inferred modify_weight(rule, W)
+    b = @inferred modify_bias(rule, b)
     @test W ≈ [1.42 -1.0; 2.84 0.0]
     @test b ≈ [-1.0, 1.42]
 end
@@ -141,7 +137,8 @@ layers = Dict(
                 @testset "$layername" begin
                     Rₖ₊₁ = layer(aₖ_dense)
                     Rₖ = similar(aₖ_dense)
-                    @inferred lrp!(Rₖ, rule, layer, aₖ_dense, Rₖ₊₁)
+                    modified_layer = modify_layer(rule, layer)
+                    @inferred lrp!(Rₖ, rule, modified_layer, aₖ_dense, Rₖ₊₁)
 
                     @test typeof(Rₖ) == typeof(aₖ_dense)
                     @test size(Rₖ) == size(aₖ_dense)
@@ -176,25 +173,29 @@ equalpairs = Dict( # these pairs of layers are all equal
 @testset "PoolingLayers" begin
     for (rulename, rule) in RULES
         @testset "$rulename" begin
-            for (layername, layers) in equalpairs
-                @testset "$layername" begin
-                    l1, l2 = layers
-                    Rₖ₊₁ = l1(aₖ)
-                    @test Rₖ₊₁ == l2(aₖ)
-                    Rₖ1 = similar(aₖ)
-                    Rₖ2 = similar(aₖ)
+            for (layername, (l1, l2)) in equalpairs
+                if is_compatible(rule, l1) && is_compatible(rule, l2)
+                    @testset "$layername" begin
+                        ml1 = @inferred modify_layer(rule, l1)
+                        ml2 = @inferred modify_layer(rule, l2)
 
-                    if isa_constant_param_rule(rule)
-                        @inferred lrp!(Rₖ1, rule, l1, aₖ, Rₖ₊₁)
-                        @inferred lrp!(Rₖ2, rule, l2, aₖ, Rₖ₊₁)
-                        @test Rₖ1 == Rₖ2
-                        @test typeof(Rₖ1) == typeof(aₖ)
-                        @test size(Rₖ1) == size(aₖ)
-                        @test_reference "references/rules/$rulename/$layername.jld2" Dict(
-                            "R" => Rₖ1
-                        ) by = (r, a) -> isapprox(r["R"], a["R"]; rtol=0.02)
-                    else
-                        @test_throws ArgumentError lrp!(Rₖ1, rule, l1, aₖ, Rₖ₊₁)
+                        Rₖ₊₁ = l1(aₖ)
+                        @test Rₖ₊₁ == l2(aₖ)
+                        Rₖ1 = similar(aₖ)
+                        Rₖ2 = similar(aₖ)
+
+                        if isa_constant_param_rule(rule)
+                            @inferred lrp!(Rₖ1, rule, ml1, aₖ, Rₖ₊₁)
+                            @inferred lrp!(Rₖ2, rule, ml2, aₖ, Rₖ₊₁)
+                            @test Rₖ1 == Rₖ2
+                            @test typeof(Rₖ1) == typeof(aₖ)
+                            @test size(Rₖ1) == size(aₖ)
+                            @test_reference "references/rules/$rulename/$layername.jld2" Dict(
+                                "R" => Rₖ1
+                            ) by = (r, a) -> isapprox(r["R"], a["R"]; rtol=0.02)
+                        else
+                            @test_throws ArgumentError lrp!(Rₖ1, rule, l1, aₖ, Rₖ₊₁)
+                        end
                     end
                 end
             end
@@ -222,18 +223,22 @@ layers = Dict(
     for (rulename, rule) in RULES
         @testset "$rulename" begin
             for (layername, layer) in layers
-                @testset "$layername" begin
-                    Rₖ₊₁ = layer(aₖ)
-                    Rₖ = similar(aₖ)
-                    if has_weight_and_bias(layer) || isa_constant_param_rule(rule)
-                        @inferred lrp!(Rₖ, rule, layer, aₖ, Rₖ₊₁)
-                        @test typeof(Rₖ) == typeof(aₖ)
-                        @test size(Rₖ) == size(aₖ)
-                        @test_reference "references/rules/$rulename/$layername.jld2" Dict(
-                            "R" => Rₖ
-                        ) by = (r, a) -> isapprox(r["R"], a["R"]; atol=1e-5, rtol=0.02)
-                    else
-                        @test_throws ArgumentError lrp!(Rₖ, rule, layer, aₖ, Rₖ₊₁)
+                if is_compatible(rule, layer)
+                    @testset "$layername" begin
+                        Rₖ₊₁ = layer(aₖ)
+                        Rₖ = similar(aₖ)
+                        modified_layer = @inferred modify_layer(rule, layer)
+
+                        if has_weight_and_bias(layer) || isa_constant_param_rule(rule)
+                            @inferred lrp!(Rₖ, rule, modified_layer, aₖ, Rₖ₊₁)
+                            @test typeof(Rₖ) == typeof(aₖ)
+                            @test size(Rₖ) == size(aₖ)
+                            @test_reference "references/rules/$rulename/$layername.jld2" Dict(
+                                "R" => Rₖ
+                            ) by = (r, a) -> isapprox(r["R"], a["R"]; atol=1e-5, rtol=0.02)
+                        else
+                            @test_throws ArgumentError lrp!(Rₖ, rule, layer, aₖ, Rₖ₊₁)
+                        end
                     end
                 end
             end
@@ -242,10 +247,14 @@ layers = Dict(
 end
 
 # Test equivalence of ZPlusRule() and AlphaBetaRule(1.0f0, 0.0f0)
-l = layers["Conv"]
-Rₖ₊₁ = l(aₖ)
+layer = layers["Conv"]
+Rₖ₊₁ = layer(aₖ)
 Rₖ_z⁺ = similar(aₖ)
 Rₖ_αβ = similar(aₖ)
-lrp!(Rₖ_z⁺, ZPlusRule(), l, aₖ, Rₖ₊₁)
-lrp!(Rₖ_αβ, AlphaBetaRule(1.0f0, 0.0f0), l, aₖ, Rₖ₊₁)
+rule = ZPlusRule()
+modified_layers = modify_layer(rule, layer)
+lrp!(Rₖ_z⁺, rule, modified_layers, aₖ, Rₖ₊₁)
+rule = AlphaBetaRule(1.0f0, 0.0f0)
+modified_layers = modify_layer(rule, layer)
+lrp!(Rₖ_αβ, rule, modified_layers, aₖ, Rₖ₊₁)
 @test Rₖ_z⁺ ≈ Rₖ_αβ


### PR DESCRIPTION
This PR gives `LRP` analyzers a `state` which pre-allocates tuples of rules and modified layers before calling `lrp!`.

This streamlines more complex rules (e.g. `AlphaBetaRule`) and removes the need for in-place modifying functions acting on the layers.

Somewhat surprisingly, this doesn't affect the performance of LRP methods.

___

## Breaking changes
Refactored user-extended functions:
- `modify_parameters` replaces `modify_param!`
- `modify_bias`       replaces `modify_bias!`
- `modify_weight`     replaces `modify_weight!`
- `modify_layer`      replaces `modify_layer!`
- `is_compatible`     replaces `check_compat` and returns a Boolean value instead of directly throwing errors

## Internal changes
Removed internal functions:
- `preactivation`
- `get_layer_resetter`

Adds:
- `LRPCompatibilityError`
- `copy_layer`
