### PR TITLE
Refactor `Explanation` struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,10 @@ Breaking changes:
     - `EpsilonRule`: argument `epsilon` replaces `ϵ` 
     - `GammaRule`: argument `gamma` replaces `γ` 
     - `AlphaBetaRule`: arguments `alpha` and `beta` replace `α`, `β` 
-- ![BREAKING][badge-breaking] Rename `LRP` analyzer keyword argument from `is_flat=false` to `flatten=true` ([#119][pr-119])
+- ![BREAKING][badge-breaking] Rename `LRP` analyzer keyword argument `is_flat=false` to `flatten=true` ([#119][pr-119])
 - ![BREAKING][badge-breaking] Remove `check_model` (replaced by non-exported `check_lrp_compat`) ([#119][pr-119])
+- ![BREAKING][badge-breaking] Replace `layerwise_relevances` field of `Explanation` return type by optional named tuple `extras`.
+    Access layerwise relevances via `extras.layerwise_relevances`. ([#126][pr-126])
 - ![BREAKING][badge-breaking] `lrp!` rule calls require extra argument `layer` ([#119][pr-119])
 - ![BREAKING][badge-breaking] Pre-allocate modified layers, replacing `modify_param!` with `modify_parameters` ([#102][pr-102])
 - ![BREAKING][badge-breaking] Remove composite `LastNTypeRule` ([#119][pr-119]) 
@@ -33,13 +35,13 @@ New features and enhancements:
 
 Improvements to documentation:
 - ![Documentation][badge-docs] Fix API reference, add diagram explaining LRP layer modification ([#105][pr-105])
+- ![Documentation][badge-docs] Fix image loading in README example
 
 Package maintenance:
 - ![Maintenance][badge-maintenance] Refactor LRP rule tests ([#103][pr-103])
 - ![Maintenance][badge-maintenance] Fix LRP benchmarks ([#104][pr-104])
 
 ### General changes
-- ![Documentation][badge-docs] Fix image loading in README example
 - ![Maintenance][badge-maintenance] Compatibility with Flux.jl `v0.14` ([#116][pr-116])
 - ![Maintenance][badge-maintenance] Drop dependency on LinearAlgebra.jl and PrettyTables.jl ([#119][pr-119])
 - ![Maintenance][badge-maintenance] Add Aqua.jl tests ([#125][pr-125])
@@ -141,6 +143,7 @@ Performance improvements:
 ![Documentation][badge-docs]
 -->
 
+[pr-126]: https://github.com/adrhill/ExplainableAI.jl/pull/126
 [pr-125]: https://github.com/adrhill/ExplainableAI.jl/pull/125
 [pr-119]: https://github.com/adrhill/ExplainableAI.jl/pull/119
 [pr-116]: https://github.com/adrhill/ExplainableAI.jl/pull/116

--- a/src/analyze_api.jl
+++ b/src/analyze_api.jl
@@ -65,12 +65,13 @@ Contains:
 * `output`: the model output
 * `neuron_selection`: the neuron index used for the attribution
 * `analyzer`: a symbol corresponding the used analyzer, e.g. `:LRP`
+* `extras`: an optional named tuple that can be used by analyzers
+    to return additional information.
 """
-struct Explanation{A,O,I,L}
+struct Explanation{A,O,I,E<:Union{Nothing, NamedTuple}}
     attribution::A
     output::O
     neuron_selection::I
     analyzer::Symbol
-    # TODO: turn into field extras of type Union{Nothing, Dict}
-    layerwise_relevances::L
+    extras::E
 end

--- a/src/analyze_api.jl
+++ b/src/analyze_api.jl
@@ -68,7 +68,7 @@ Contains:
 * `extras`: an optional named tuple that can be used by analyzers
     to return additional information.
 """
-struct Explanation{A,O,I,E<:Union{Nothing, NamedTuple}}
+struct Explanation{A,O,I,E<:Union{Nothing,NamedTuple}}
     attribution::A
     output::O
     neuron_selection::I

--- a/src/gradient.jl
+++ b/src/gradient.jl
@@ -28,7 +28,7 @@ function (analyzer::Gradient)(input, ns::AbstractNeuronSelector)
     output = analyzer.model(input)
     output_indices = ns(output)
     grad = gradients_wrt_batch(analyzer.model, input, output_indices)
-    return Explanation(grad, output, output_indices, :Gradient, Nothing)
+    return Explanation(grad, output, output_indices, :Gradient, nothing)
 end
 
 """
@@ -47,7 +47,7 @@ function (analyzer::InputTimesGradient)(input, ns::AbstractNeuronSelector)
     output = analyzer.model(input)
     output_indices = ns(output)
     attr = input .* gradients_wrt_batch(analyzer.model, input, output_indices)
-    return Explanation(attr, output, output_indices, :InputTimesGradient, Nothing)
+    return Explanation(attr, output, output_indices, :InputTimesGradient, nothing)
 end
 
 """

--- a/src/input_augmentation.jl
+++ b/src/input_augmentation.jl
@@ -109,7 +109,7 @@ function (aug::NoiseAugmentation)(input, ns::AbstractNeuronSelector)
         output,
         output_indices,
         augmented_expl.analyzer,
-        Nothing,
+        nothing,
     )
 end
 
@@ -148,7 +148,7 @@ function (aug::InterpolationAugmentation)(
     # Average gradients and compute explanation
     expl = (input - input_ref) .* reduce_augmentation(augmented_expl.attribution, aug.n)
 
-    return Explanation(expl, output, output_indices, augmented_expl.analyzer, Nothing)
+    return Explanation(expl, output, output_indices, augmented_expl.analyzer, nothing)
 end
 
 """

--- a/src/lrp/lrp.jl
+++ b/src/lrp/lrp.jl
@@ -66,19 +66,9 @@ function (lrp::LRP)(
         )
     end
 
-    if layerwise_relevances
-        extras = (layerwise_relevances = rels,)
-    else
-        extras = nothing
-    end
+    extras = layerwise_relevances ? (layerwise_relevances=rels,) : nothing
 
-    return Explanation(
-        first(rels),
-        last(acts),
-        ns(last(acts)),
-        :LRP,
-        extras
-    )
+    return Explanation(first(rels), last(acts), ns(last(acts)), :LRP, extras)
 end
 
 function lrp!(Rₖ, rules::ChainTuple, layers::Chain, modified_layers::ChainTuple, aₖ, Rₖ₊₁)

--- a/src/lrp/lrp.jl
+++ b/src/lrp/lrp.jl
@@ -66,12 +66,18 @@ function (lrp::LRP)(
         )
     end
 
+    if layerwise_relevances
+        extras = (layerwise_relevances = rels,)
+    else
+        extras = nothing
+    end
+
     return Explanation(
         first(rels),
         last(acts),
         ns(last(acts)),
         :LRP,
-        ifelse(layerwise_relevances, rels, Nothing),
+        extras
     )
 end
 


### PR DESCRIPTION
Remove LRP-specific `layerwise_relevances` and replace it by optional named tuple `extras`.

Closes #123.