### PR TITLE
Rename composite primitives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ Breaking changes:
 - ![BREAKING][badge-breaking] `lrp!` rule calls require extra argument `layer` ([#119][pr-119])
 - ![BREAKING][badge-breaking] Pre-allocate modified layers, replacing `modify_param!` with `modify_parameters` ([#102][pr-102])
 - ![BREAKING][badge-breaking] Remove composite `LastNTypeRule` ([#119][pr-119]) 
+- ![BREAKING][badge-breaking] Rename composite primitives to avoid confusion with LRP rules ([#130][pr-130])
+    - rename `*Rule` to `*Map`
+    - rename `*TypeRule` to `*TypeMap`
 
 New features and enhancements:
 - ![Feature][badge-feature] Support nested Flux Chains ([#119][pr-119])
@@ -145,6 +148,7 @@ Performance improvements:
 ![Documentation][badge-docs]
 -->
 
+[pr-130]: https://github.com/adrhill/ExplainableAI.jl/pull/130
 [pr-129]: https://github.com/adrhill/ExplainableAI.jl/pull/129
 [pr-128]: https://github.com/adrhill/ExplainableAI.jl/pull/128
 [pr-126]: https://github.com/adrhill/ExplainableAI.jl/pull/126

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -62,20 +62,20 @@ Composite
 ### [Composite primitives](@id composite_primitive_api)
 Composite primitives that apply a single rule:
 ```@docs
-LayerRule
-GlobalRule
-RangeRule
-FirstLayerRule
-LastLayerRule
+LayerMap
+GlobalMap
+RangeMap
+FirstLayerMap
+LastLayerMap
 ```
 
 Composite primitives that apply a set of rules to multiple layers:
 ```@docs
-GlobalTypeRule
-RangeTypeRule
-FirstLayerTypeRule
-LastLayerTypeRule
-FirstNTypeRule
+GlobalTypeMap
+RangeTypeMap
+FirstLayerTypeMap
+LastLayerTypeMap
+FirstNTypeMap
 ```
 
 ### [Default composites](@id default_composite_api)

--- a/docs/src/literate/advanced_lrp.jl
+++ b/docs/src/literate/advanced_lrp.jl
@@ -48,11 +48,11 @@ heatmap(input, analyzer)
 # To obtain the same set of rules as in the previous example, we can define
 composite = Composite(
     ZeroRule(),                              # default rule
-    GlobalTypeRule(
+    GlobalTypeMap(
         Conv => GammaRule(),                 # apply GammaRule on all convolutional layers
         MaxPool => EpsilonRule(),            # apply EpsilonRule on all pooling-layers
     ),
-    FirstLayerRule(ZBoxRule(0.0f0, 1.0f0)),  # apply ZBoxRule on the first layer
+    FirstLayerMap(ZBoxRule(0.0f0, 1.0f0)),   # apply ZBoxRule on the first layer
 )
 
 # We now construct an LRP analyzer from `composite`
@@ -66,18 +66,18 @@ heatmap(input, analyzer)
 # The following [Composite primitives](@ref composite_primitive_api) can used to construct a [`Composite`](@ref).
 #
 # To apply a single rule, use:
-# * [`LayerRule`](@ref) to apply a rule to the `n`-th layer of a model
-# * [`GlobalRule`](@ref) to apply a rule to all layers
-# * [`RangeRule`](@ref) to apply a rule to a positional range of layers
-# * [`FirstLayerRule`](@ref) to apply a rule to the first layer
-# * [`LastLayerRule`](@ref) to apply a rule to the last layer
+# * [`LayerMap`](@ref) to apply a rule to the `n`-th layer of a model
+# * [`GlobalMap`](@ref) to apply a rule to all layers
+# * [`RangeMap`](@ref) to apply a rule to a positional range of layers
+# * [`FirstLayerMap`](@ref) to apply a rule to the first layer
+# * [`LastLayerMap`](@ref) to apply a rule to the last layer
 #
 # To apply a set of rules to layers based on their type, use:
-# * [`GlobalTypeRule`](@ref) to apply a dictionary that maps layer types to LRP-rules
-# * [`RangeTypeRule`](@ref) for a `TypeRule` on generalized ranges
-# * [`FirstLayerTypeRule`](@ref) for a `TypeRule` on the first layer of a model
-# * [`LastLayerTypeRule`](@ref) for a `TypeRule` on the last layer
-# * [`FirstNTypeRule`](@ref) for a `TypeRule` on the first `n` layers
+# * [`GlobalTypeMap`](@ref) to apply a dictionary that maps layer types to LRP-rules
+# * [`RangeTypeMap`](@ref) for a `TypeMap` on generalized ranges
+# * [`FirstLayerTypeMap`](@ref) for a `TypeMap` on the first layer of a model
+# * [`LastLayerTypeMap`](@ref) for a `TypeMap` on the last layer
+# * [`FirstNTypeMap`](@ref) for a `TypeMap` on the first `n` layers
 #
 # Primitives are called sequentially in the order the `Composite` was created with
 # and overwrite rules specified by previous primitives.

--- a/src/ExplainableAI.jl
+++ b/src/ExplainableAI.jl
@@ -50,9 +50,9 @@ export PassRule, ZBoxRule, ZPlusRule, AlphaBetaRule, GeneralizedGammaRule
 
 # LRP composites
 export Composite, AbstractCompositePrimitive
-export LayerRule, GlobalRule, RangeRule, FirstLayerRule, LastLayerRule
-export GlobalTypeRule, RangeTypeRule, FirstLayerTypeRule, LastLayerTypeRule
-export FirstNTypeRule
+export LayerMap, GlobalMap, RangeMap, FirstLayerMap, LastLayerMap
+export GlobalTypeMap, RangeTypeMap, FirstLayerTypeMap, LastLayerTypeMap
+export FirstNTypeMap
 export lrp_rules
 # Default composites
 export EpsilonGammaBox, EpsilonPlus, EpsilonAlpha2Beta1, EpsilonPlusFlat

--- a/src/lrp/composite.jl
+++ b/src/lrp/composite.jl
@@ -8,158 +8,152 @@ struct Composite{T<:Union{Tuple,AbstractVector}}
     primitives::T
 end
 Composite(primitives...) = Composite(primitives)
-Composite(rule::AbstractLRPRule, prims...) = Composite((GlobalRule(rule), prims...))
+Composite(rule::AbstractLRPRule, prims...) = Composite((GlobalMap(rule), prims...))
 
-# TODO: Documentation and new lrp_rules function, add to Changelog
-# - new lrp_rules function
-# - deprecation of LastNTypeRule
-# - document new primitive interface
-
-# TODO: rename primitives to e.g. "assigners" avoid confusion with LRP rules
 # TODO: add LambdaRule
-# TODO: add LambdaTypeRule
+# TODO: add LambdaTypeMap
 
 #=================#
 # Rule primitives #
 #=================#
 
 abstract type AbstractCompositePrimitive end
-abstract type AbstractRulePrimitive <: AbstractCompositePrimitive end
+abstract type AbstractCompositeMap <: AbstractCompositePrimitive end
 
 """
-    GlobalRule(rule)
+    GlobalMap(rule)
 
-Composite primitive that applies LRP-rule `rule` to all layers in the model.
+Composite primitive that maps LRP-rule `rule` to all layers in the model.
 
 See [`Composite`](@ref) for an example.
 """
-struct GlobalRule{R<:AbstractLRPRule} <: AbstractRulePrimitive
+struct GlobalMap{R<:AbstractLRPRule} <: AbstractCompositeMap
     rule::R
 end
 
 """
-    LayerRule(n, rule)
+    LayerMap(n, rule)
 
-Composite primitive that applies LRP-rule `rule` to the `n`-th layer in the model.
+Composite primitive that maps LRP-rule `rule` to the `n`-th layer in the model.
 
 See [`Composite`](@ref) for an example.
 """
-struct LayerRule{R<:AbstractLRPRule} <: AbstractRulePrimitive
+struct LayerMap{R<:AbstractLRPRule} <: AbstractCompositeMap
     n::Int
     rule::R
 end
 
 """
-    RangeRule(range, rule)
+    RangeMap(range, rule)
 
-Composite primitive that applies LRP-rule `rule` to the specified positional `range`
+Composite primitive that maps LRP-rule `rule` to the specified positional `range`
 of layers in the model.
 
 See [`Composite`](@ref) for an example.
 """
-struct RangeRule{T<:AbstractRange,R<:AbstractLRPRule} <: AbstractRulePrimitive
+struct RangeMap{T<:AbstractRange,R<:AbstractLRPRule} <: AbstractCompositeMap
     range::T
     rule::R
 end
 
 """
-    FirstLayerRule(rule)
+    FirstLayerMap(rule)
 
-Composite primitive that applies LRP-rule `rule` to the first layer in the model.
+Composite primitive that maps LRP-rule `rule` to the first layer in the model.
 
 See [`Composite`](@ref) for an example.
 """
-struct FirstLayerRule{R<:AbstractLRPRule} <: AbstractRulePrimitive
+struct FirstLayerMap{R<:AbstractLRPRule} <: AbstractCompositeMap
     rule::R
 end
 
 """
-    LastLayerRule(rule)
+    LastLayerMap(rule)
 
-Composite primitive that applies LRP-rule `rule` to the last layer in the model.
+Composite primitive that maps LRP-rule `rule` to the last layer in the model.
 
 See [`Composite`](@ref) for an example.
 """
-struct LastLayerRule{R<:AbstractLRPRule} <: AbstractRulePrimitive
+struct LastLayerMap{R<:AbstractLRPRule} <: AbstractCompositeMap
     rule::R
 end
 
 #=====================#
-# TypeRule primitives #
+# TypeMap primitives #
 #=====================#
 
-abstract type AbstractTypeRulePrimitive <: AbstractCompositePrimitive end
-const TypeRulePair = Pair{<:Type,<:AbstractLRPRule}
+abstract type AbstractCompositeTypeMap <: AbstractCompositePrimitive end
+const TypeMapPair = Pair{<:Type,<:AbstractLRPRule}
 
 """
-    GlobalTypeRule(map)
+    GlobalTypeMap(map)
 
 Composite primitive that maps layer types to LRP rules based on a list of
 type-rule-pairs `map`.
 
 See [`Composite`](@ref) for an example.
 """
-struct GlobalTypeRule{T<:AbstractVector{<:TypeRulePair}} <: AbstractTypeRulePrimitive
+struct GlobalTypeMap{T<:AbstractVector{<:TypeMapPair}} <: AbstractCompositeTypeMap
     map::T
 end
 
 """
-    RangeTypeRule(range, map)
+    RangeTypeMap(range, map)
 
 Composite primitive that maps layer types to LRP rules based on a list of
 type-rule-pairs `map` within the specified `range` of layers in the model.
 
 See [`Composite`](@ref) for an example.
 """
-struct RangeTypeRule{R<:AbstractRange,T<:AbstractVector{<:TypeRulePair}} <:
-       AbstractTypeRulePrimitive
+struct RangeTypeMap{R<:AbstractRange,T<:AbstractVector{<:TypeMapPair}} <:
+       AbstractCompositeTypeMap
     range::R
     map::T
 end
 
 """
-    FirstNTypeRule(n, map)
+    FirstNTypeMap(n, map)
 
 Composite primitive that maps layer types to LRP rules based on a list of
 type-rule-pairs `map` within the first `n` layers in the model.
 
 See [`Composite`](@ref) for an example.
 """
-struct FirstNTypeRule{T<:AbstractVector{<:TypeRulePair}} <: AbstractTypeRulePrimitive
+struct FirstNTypeMap{T<:AbstractVector{<:TypeMapPair}} <: AbstractCompositeTypeMap
     n::Int
     map::T
 end
 
 """
-    FirstLayerTypeRule(map)
+    FirstLayerTypeMap(map)
 
 Composite primitive that maps the type of the first layer of the model to LRP rules
 based on a list of type-rule-pairs `map`.
 
 See [`Composite`](@ref) for an example.
 """
-struct FirstLayerTypeRule{T<:AbstractVector{<:TypeRulePair}} <: AbstractTypeRulePrimitive
+struct FirstLayerTypeMap{T<:AbstractVector{<:TypeMapPair}} <: AbstractCompositeTypeMap
     map::T
 end
 
 """
-    LastLayerTypeRule(map)
+    LastLayerTypeMap(map)
 
 Composite primitive that maps the type of the last layer of the model to LRP rules
 based on a list of type-rule-pairs `map`.
 
 See [`Composite`](@ref) for an example.
 """
-struct LastLayerTypeRule{T<:AbstractVector{<:TypeRulePair}} <: AbstractTypeRulePrimitive
+struct LastLayerTypeMap{T<:AbstractVector{<:TypeMapPair}} <: AbstractCompositeTypeMap
     map::T
 end
 
 # Convenience constructors
-GlobalTypeRule(ps::Vararg{TypeRulePair})     = GlobalTypeRule([ps...])
-RangeTypeRule(r, ps::Vararg{TypeRulePair})   = RangeTypeRule(r, [ps...])
-FirstLayerTypeRule(ps::Vararg{TypeRulePair}) = FirstLayerTypeRule([ps...])
-LastLayerTypeRule(ps::Vararg{TypeRulePair})  = LastLayerTypeRule([ps...])
-FirstNTypeRule(n, ps::Vararg{TypeRulePair})  = FirstNTypeRule(n, [ps...])
+GlobalTypeMap(ps::Vararg{TypeMapPair})     = GlobalTypeMap([ps...])
+RangeTypeMap(r, ps::Vararg{TypeMapPair})   = RangeTypeMap(r, [ps...])
+FirstLayerTypeMap(ps::Vararg{TypeMapPair}) = FirstLayerTypeMap([ps...])
+LastLayerTypeMap(ps::Vararg{TypeMapPair})  = LastLayerTypeMap([ps...])
+FirstNTypeMap(n, ps::Vararg{TypeMapPair})  = FirstNTypeMap(n, [ps...])
 
 #=====================#
 # LRP-rule assignment #
@@ -184,25 +178,25 @@ function lrp_rules(model, c::Composite)
     first_key = first_element(keys)
     last_key = last_element(keys)
 
-    get_rule(r::LayerRule, _, key) = ifelse(first(key) == r.n, r.rule, nothing)
-    get_rule(r::GlobalRule, _, _key) = r.rule
-    get_rule(r::RangeRule, _, key) = ifelse(first(key) ∈ r.range, r.rule, nothing)
-    get_rule(r::FirstLayerRule, _, key) = ifelse(key == first_key, r.rule, nothing)
-    get_rule(r::LastLayerRule, _, key) = ifelse(key == last_key, r.rule, nothing)
+    get_rule(r::LayerMap, _, key) = ifelse(first(key) == r.n, r.rule, nothing)
+    get_rule(r::GlobalMap, _, _key) = r.rule
+    get_rule(r::RangeMap, _, key) = ifelse(first(key) ∈ r.range, r.rule, nothing)
+    get_rule(r::FirstLayerMap, _, key) = ifelse(key == first_key, r.rule, nothing)
+    get_rule(r::LastLayerMap, _, key) = ifelse(key == last_key, r.rule, nothing)
 
-    function get_rule(r::GlobalTypeRule, layer, _key)
+    function get_rule(r::GlobalTypeMap, layer, _key)
         return get_type_rule(layer, r.map)
     end
-    function get_rule(r::RangeTypeRule, layer, key)
+    function get_rule(r::RangeTypeMap, layer, key)
         return ifelse(first(key) ∈ r.range, get_type_rule(layer, r.map), nothing)
     end
-    function get_rule(r::FirstLayerTypeRule, layer, key)
+    function get_rule(r::FirstLayerTypeMap, layer, key)
         return ifelse(key == first_key, get_type_rule(layer, r.map), nothing)
     end
-    function get_rule(r::LastLayerTypeRule, layer, key)
+    function get_rule(r::LastLayerTypeMap, layer, key)
         return ifelse(key == last_key, get_type_rule(layer, r.map), nothing)
     end
-    function get_rule(r::FirstNTypeRule, layer, key)
+    function get_rule(r::FirstNTypeMap, layer, key)
         return ifelse(first(key) ∈ 1:(r.n), get_type_rule(layer, r.map), nothing)
     end
 
@@ -225,31 +219,31 @@ Automatically contructs a list of LRP-rules by sequentially applying composite p
 
 # Primitives
 To apply a single rule, use:
-* [`LayerRule`](@ref) to apply a rule to the `n`-th layer of a model
-* [`GlobalRule`](@ref) to apply a rule to all layers
-* [`RangeRule`](@ref) to apply a rule to a positional range of layers
-* [`FirstLayerRule`](@ref) to apply a rule to the first layer
-* [`LastLayerRule`](@ref) to apply a rule to the last layer
+* [`LayerMap`](@ref) to apply a rule to the `n`-th layer of a model
+* [`GlobalMap`](@ref) to apply a rule to all layers
+* [`RangeMap`](@ref) to apply a rule to a positional range of layers
+* [`FirstLayerMap`](@ref) to apply a rule to the first layer
+* [`LastLayerMap`](@ref) to apply a rule to the last layer
 
 To apply a set of rules to layers based on their type, use:
-* [`GlobalTypeRule`](@ref) to apply a dictionary that maps layer types to LRP-rules
-* [`RangeTypeRule`](@ref) for a `TypeRule` on generalized ranges
-* [`FirstLayerTypeRule`](@ref) for a `TypeRule` on the first layer of a model
-* [`LastLayerTypeRule`](@ref) for a `TypeRule` on the last layer
-* [`FirstNTypeRule`](@ref) for a `TypeRule` on the first `n` layers
+* [`GlobalTypeMap`](@ref) to apply a dictionary that maps layer types to LRP-rules
+* [`RangeTypeMap`](@ref) for a `TypeMap` on generalized ranges
+* [`FirstLayerTypeMap`](@ref) for a `TypeMap` on the first layer of a model
+* [`LastLayerTypeMap`](@ref) for a `TypeMap` on the last layer
+* [`FirstNTypeMap`](@ref) for a `TypeMap` on the first `n` layers
 
 # Example
 Using a flattened VGG11 model:
 ```julia-repl
 julia> composite = Composite(
-           GlobalTypeRule(
+           GlobalTypeMap(
                ConvLayer => AlphaBetaRule(),
                Dense => EpsilonRule(),
                PoolingLayer => EpsilonRule(),
                DropoutLayer => PassRule(),
                ReshapingLayer => PassRule(),
            ),
-           FirstNTypeRule(7, Conv => FlatRule()),
+           FirstNTypeMap(7, Conv => FlatRule()),
        );
 
 julia> analyzer = LRP(model, composite);

--- a/src/lrp/composite_presets.jl
+++ b/src/lrp/composite_presets.jl
@@ -9,14 +9,14 @@ $(repr("text/plain", EpsilonGammaBox(-3.0f0, 3.0f0)))
 """
 function EpsilonGammaBox(low, high; epsilon=1.0f-6, gamma=0.25f0)
     return Composite(
-        GlobalTypeRule(
+        GlobalTypeMap(
             ConvLayer        => GammaRule(gamma),
             Dense            => EpsilonRule(epsilon),
             DropoutLayer     => PassRule(),
             ReshapingLayer   => PassRule(),
             typeof(identity) => PassRule(),
         ),
-        FirstLayerTypeRule(ConvLayer => ZBoxRule(low, high)),
+        FirstLayerTypeMap(ConvLayer => ZBoxRule(low, high)),
     )
 end
 
@@ -31,7 +31,7 @@ $(repr("text/plain", EpsilonPlus()))
 """
 function EpsilonPlus(; epsilon=1.0f-6)
     return Composite(
-        GlobalTypeRule(
+        GlobalTypeMap(
             ConvLayer        => ZPlusRule(),
             Dense            => EpsilonRule(epsilon),
             DropoutLayer     => PassRule(),
@@ -52,7 +52,7 @@ $(repr("text/plain", EpsilonAlpha2Beta1()))
 """
 function EpsilonAlpha2Beta1(; epsilon=1.0f-6)
     return Composite(
-        GlobalTypeRule(
+        GlobalTypeMap(
             ConvLayer        => AlphaBetaRule(2.0f0, 1.0f0),
             Dense            => EpsilonRule(epsilon),
             DropoutLayer     => PassRule(),
@@ -73,14 +73,14 @@ $(repr("text/plain", EpsilonPlusFlat()))
 """
 function EpsilonPlusFlat(; epsilon=1.0f-6)
     return Composite(
-        GlobalTypeRule(
+        GlobalTypeMap(
             ConvLayer        => ZPlusRule(),
             Dense            => EpsilonRule(epsilon),
             DropoutLayer     => PassRule(),
             ReshapingLayer   => PassRule(),
             typeof(identity) => PassRule(),
         ),
-        FirstLayerTypeRule(ConvLayer => FlatRule(), Dense => FlatRule()),
+        FirstLayerTypeMap(ConvLayer => FlatRule(), Dense => FlatRule()),
     )
 end
 
@@ -95,13 +95,13 @@ $(repr("text/plain", EpsilonAlpha2Beta1Flat()))
 """
 function EpsilonAlpha2Beta1Flat(; epsilon=1.0f-6)
     return Composite(
-        GlobalTypeRule(
+        GlobalTypeMap(
             ConvLayer        => AlphaBetaRule(2.0f0, 1.0f0),
             Dense            => EpsilonRule(epsilon),
             DropoutLayer     => PassRule(),
             ReshapingLayer   => PassRule(),
             typeof(identity) => PassRule(),
         ),
-        FirstLayerTypeRule(ConvLayer => FlatRule(), Dense => FlatRule()),
+        FirstLayerTypeMap(ConvLayer => FlatRule(), Dense => FlatRule()),
     )
 end

--- a/src/lrp/show.jl
+++ b/src/lrp/show.jl
@@ -107,16 +107,16 @@ end
 # Composite #
 #===========#
 
-_range_string(r::LayerRule)         = "layer $(r.n)"
-_range_string(::GlobalRule)         = "all layers"
-_range_string(r::RangeRule)         = "layers $(r.range)"
-_range_string(::FirstLayerRule)     = "first layer"
-_range_string(::LastLayerRule)      = "last layer"
-_range_string(r::GlobalTypeRule)    = "all layers"
-_range_string(r::RangeTypeRule)     = "layers $(r.range)"
-_range_string(::FirstLayerTypeRule) = "first layer"
-_range_string(::LastLayerTypeRule)  = "last layer"
-_range_string(r::FirstNTypeRule)    = "layers $(1:r.n)"
+_range_string(r::LayerMap)         = "layer $(r.n)"
+_range_string(::GlobalMap)         = "all layers"
+_range_string(r::RangeMap)         = "layers $(r.range)"
+_range_string(::FirstLayerMap)     = "first layer"
+_range_string(::LastLayerMap)      = "last layer"
+_range_string(r::GlobalTypeMap)    = "all layers"
+_range_string(r::RangeTypeMap)     = "layers $(r.range)"
+_range_string(::FirstLayerTypeMap) = "first layer"
+_range_string(::LastLayerTypeMap)  = "last layer"
+_range_string(r::FirstNTypeMap)    = "layers $(1:r.n)"
 
 function Base.show(io::IO, m::MIME"text/plain", c::Composite)
     println(io, "Composite", "(")
@@ -126,7 +126,7 @@ function Base.show(io::IO, m::MIME"text/plain", c::Composite)
     println(io, ")")
 end
 
-function _show_primitive(io::IO, r::AbstractRulePrimitive, indent::Int=0)
+function _show_primitive(io::IO, r::AbstractCompositeMap, indent::Int=0)
     print(io, " "^indent, typename(r), ": ")
     printstyled(io, _range_string(r); color=COLOR_RANGE)
     print(io, " => ")
@@ -134,7 +134,7 @@ function _show_primitive(io::IO, r::AbstractRulePrimitive, indent::Int=0)
     println(io, ",")
 end
 
-function _show_primitive(io::IO, r::AbstractTypeRulePrimitive, indent::Int=0)
+function _show_primitive(io::IO, r::AbstractCompositeTypeMap, indent::Int=0)
     print(io, " "^indent, rpad(typename(r) * "(", 20))
     printstyled(io, "# on ", _range_string(r); color=COLOR_COMMENT)
     println(io)
@@ -150,7 +150,7 @@ function _print_rules(io::IO, rs, indent::Int=0)
     end
 end
 
-function _print_type_rule(io::IO, r::TypeRulePair)
+function _print_type_rule(io::IO, r::TypeMapPair)
     printstyled(io, r.first; color=COLOR_TYPE)
     print(io, " => ")
     printstyled(io, r.second; color=COLOR_RULE)

--- a/test/references/show/EpsilonAlpha2Beta1.txt
+++ b/test/references/show/EpsilonAlpha2Beta1.txt
@@ -1,5 +1,5 @@
 Composite(
-  GlobalTypeRule(     # on all layers
+  GlobalTypeMap(      # on all layers
     Union{Conv, ConvTranspose, CrossCor} => AlphaBetaRule{Float32}(2.0f0, 1.0f0),
     Dense => EpsilonRule{Float32}(1.0f-6),
     Union{typeof(dropout), AlphaDropout, Dropout} => PassRule(),

--- a/test/references/show/EpsilonAlpha2Beta1Flat.txt
+++ b/test/references/show/EpsilonAlpha2Beta1Flat.txt
@@ -1,12 +1,12 @@
 Composite(
-  GlobalTypeRule(     # on all layers
+  GlobalTypeMap(      # on all layers
     Union{Conv, ConvTranspose, CrossCor} => AlphaBetaRule{Float32}(2.0f0, 1.0f0),
     Dense => EpsilonRule{Float32}(1.0f-6),
     Union{typeof(dropout), AlphaDropout, Dropout} => PassRule(),
     Union{typeof(flatten), typeof(MLUtils.flatten)} => PassRule(),
     typeof(identity) => PassRule(),
   ),
-  FirstLayerTypeRule( # on first layer
+  FirstLayerTypeMap(  # on first layer
     Union{Conv, ConvTranspose, CrossCor} => FlatRule(),
     Dense => FlatRule(),
   ),

--- a/test/references/show/EpsilonGammaBox.txt
+++ b/test/references/show/EpsilonGammaBox.txt
@@ -1,12 +1,12 @@
 Composite(
-  GlobalTypeRule(     # on all layers
+  GlobalTypeMap(      # on all layers
     Union{Conv, ConvTranspose, CrossCor} => GammaRule{Float32}(0.25f0),
     Dense => EpsilonRule{Float32}(1.0f-6),
     Union{typeof(dropout), AlphaDropout, Dropout} => PassRule(),
     Union{typeof(flatten), typeof(MLUtils.flatten)} => PassRule(),
     typeof(identity) => PassRule(),
   ),
-  FirstLayerTypeRule( # on first layer
+  FirstLayerTypeMap(  # on first layer
     Union{Conv, ConvTranspose, CrossCor} => ZBoxRule{Float32}(-3.0f0, 3.0f0),
   ),
 )

--- a/test/references/show/EpsilonPlus.txt
+++ b/test/references/show/EpsilonPlus.txt
@@ -1,5 +1,5 @@
 Composite(
-  GlobalTypeRule(     # on all layers
+  GlobalTypeMap(      # on all layers
     Union{Conv, ConvTranspose, CrossCor} => ZPlusRule(),
     Dense => EpsilonRule{Float32}(1.0f-6),
     Union{typeof(dropout), AlphaDropout, Dropout} => PassRule(),

--- a/test/references/show/EpsilonPlusFlat.txt
+++ b/test/references/show/EpsilonPlusFlat.txt
@@ -1,12 +1,12 @@
 Composite(
-  GlobalTypeRule(     # on all layers
+  GlobalTypeMap(      # on all layers
     Union{Conv, ConvTranspose, CrossCor} => ZPlusRule(),
     Dense => EpsilonRule{Float32}(1.0f-6),
     Union{typeof(dropout), AlphaDropout, Dropout} => PassRule(),
     Union{typeof(flatten), typeof(MLUtils.flatten)} => PassRule(),
     typeof(identity) => PassRule(),
   ),
-  FirstLayerTypeRule( # on first layer
+  FirstLayerTypeMap(  # on first layer
     Union{Conv, ConvTranspose, CrossCor} => FlatRule(),
     Dense => FlatRule(),
   ),

--- a/test/references/show/composite1.txt
+++ b/test/references/show/composite1.txt
@@ -1,19 +1,19 @@
 Composite(
-  GlobalRule: all layers => ZeroRule(),
-  GlobalRule: all layers => PassRule(),
-  GlobalTypeRule(     # on all layers
+  GlobalMap: all layers => ZeroRule(),
+  GlobalMap: all layers => PassRule(),
+  GlobalTypeMap(      # on all layers
     Union{Conv, ConvTranspose, CrossCor} => AlphaBetaRule{Float32}(2.0f0, 1.0f0),
     Dense => EpsilonRule{Float32}(1.0f-6),
     Union{GlobalMaxPool, GlobalMeanPool, AdaptiveMaxPool, AdaptiveMeanPool, MaxPool, MeanPool} => EpsilonRule{Float32}(1.0f-6),
   ),
-  FirstNTypeRule(     # on layers 1:7
+  FirstNTypeMap(      # on layers 1:7
     Conv => FlatRule(),
   ),
-  RangeTypeRule(      # on layers 4:10
+  RangeTypeMap(       # on layers 4:10
     Union{GlobalMaxPool, GlobalMeanPool, AdaptiveMaxPool, AdaptiveMeanPool, MaxPool, MeanPool} => EpsilonRule{Float32}(1.0f-5),
   ),
-  LayerRule: layer 9 => AlphaBetaRule{Float32}(1.0f0, 0.0f0),
-  FirstLayerRule: first layer => ZBoxRule{Float32}(-3.0f0, 3.0f0),
-  RangeRule: layers 18:19 => ZeroRule(),
-  LastLayerRule: last layer => PassRule(),
+  LayerMap: layer 9 => AlphaBetaRule{Float32}(1.0f0, 0.0f0),
+  FirstLayerMap: first layer => ZBoxRule{Float32}(-3.0f0, 3.0f0),
+  RangeMap: layers 18:19 => ZeroRule(),
+  LastLayerMap: last layer => PassRule(),
 )

--- a/test/references/show/composite2.txt
+++ b/test/references/show/composite2.txt
@@ -1,9 +1,9 @@
 Composite(
-  LastLayerTypeRule(  # on last layer
+  LastLayerTypeMap(   # on last layer
     Dense => EpsilonRule{Float32}(2.0f-5),
     Conv => EpsilonRule{Float32}(0.0002f0),
   ),
-  FirstLayerTypeRule( # on first layer
+  FirstLayerTypeMap(  # on first layer
     Dense => AlphaBetaRule{Float32}(1.0f0, 0.0f0),
     Conv => AlphaBetaRule{Float32}(2.0f0, 1.0f0),
   ),

--- a/test/test_composite.jl
+++ b/test/test_composite.jl
@@ -22,18 +22,18 @@ end
 # This composite is non-sensical, but covers many composite primitives
 composite1 = Composite(
     ZeroRule(), # default rule
-    GlobalRule(PassRule()), # override default rule
-    GlobalTypeRule(
+    GlobalMap(PassRule()), # override default rule
+    GlobalTypeMap(
         ConvLayer    => AlphaBetaRule(2.0f0, 1.0f0),
         Dense        => EpsilonRule(1.0f-6),
         PoolingLayer => EpsilonRule(1.0f-6),
     ),
-    FirstNTypeRule(7, Conv => FlatRule()),
-    RangeTypeRule(4:10, PoolingLayer => EpsilonRule(1.0f-5)),
-    LayerRule(9, AlphaBetaRule(1.0f0, 0.0f0)),
-    FirstLayerRule(ZBoxRule(-3.0f0, 3.0f0)),
-    RangeRule(18:19, ZeroRule()),
-    LastLayerRule(PassRule()),
+    FirstNTypeMap(7, Conv => FlatRule()),
+    RangeTypeMap(4:10, PoolingLayer => EpsilonRule(1.0f-5)),
+    LayerMap(9, AlphaBetaRule(1.0f0, 0.0f0)),
+    FirstLayerMap(ZBoxRule(-3.0f0, 3.0f0)),
+    RangeMap(18:19, ZeroRule()),
+    LastLayerMap(PassRule()),
 )
 @test_reference "references/show/composite1.txt" repr("text/plain", composite1)
 
@@ -72,8 +72,8 @@ model2 = Chain(
     Dense(84 => 10),
 )
 composite2 = Composite(
-    LastLayerTypeRule(Dense => EpsilonRule(2.0f-5), Conv => EpsilonRule(2.0f-4)),
-    FirstLayerTypeRule(
+    LastLayerTypeMap(Dense => EpsilonRule(2.0f-5), Conv => EpsilonRule(2.0f-4)),
+    FirstLayerTypeMap(
         Dense => AlphaBetaRule(1.0f0, 0.0f0), Conv => AlphaBetaRule(2.0f0, 1.0f0)
     ),
 )
@@ -93,14 +93,14 @@ analyzer2 = LRP(model2, composite2; flatten=false)
 @test_reference "references/show/lrp2.txt" repr("text/plain", analyzer2)
 
 composite3 = Composite(
-    GlobalTypeRule(
+    GlobalTypeMap(
         ConvLayer      => ZPlusRule(),
         Dense          => EpsilonRule(),
         DropoutLayer   => PassRule(),
         ReshapingLayer => PassRule(),
     ),
-    FirstLayerTypeRule(ConvLayer => FlatRule(), Dense => FlatRule()),
-    LastLayerRule(EpsilonRule(1.0f-5)),
+    FirstLayerTypeMap(ConvLayer => FlatRule(), Dense => FlatRule()),
+    LastLayerMap(EpsilonRule(1.0f-5)),
 )
 
 analyzer3 = LRP(model, composite3; flatten=false)


### PR DESCRIPTION
- rename `*Rule` to `*Map` (e.g. `FirstLayerRule` to `FirstLayerMap`)
- rename `*TypeRule` to `*TypeMap`