### PR TITLE
Rename `Explanation` field `attribution` to `val`

### DIFF
--- a/docs/src/literate/example.jl
+++ b/docs/src/literate/example.jl
@@ -1,6 +1,6 @@
 # # Getting started
 # ExplainableAI.jl can be used on any classifier.
-# In this first example, we will look at attributions on a LeNet5 model that was pretrained on MNIST.
+# In this first example, we will look at explanations on a LeNet5 model that was pretrained on MNIST.
 #
 # ### Loading the model
 #md # !!! note
@@ -43,7 +43,7 @@ input = reshape(x, 28, 28, 1, :);
 
 #md # !!! warning "Input format"
 #md #
-#md #     For any attribution of a model, ExplainableAI.jl assumes the batch dimension to be come last in the input.
+#md #     For any explanation of a model, ExplainableAI.jl assumes the batch dimension to be come last in the input.
 #md #
 #md #     For the purpose of heatmapping, the input is assumed to be in WHCN order
 #md #     (width, height, channels, batch), which is Flux.jl's convention.
@@ -55,10 +55,11 @@ analyzer = LRP(model)
 expl = analyze(input, analyzer);
 
 # This [`Explanation`](@ref) bundles the following data:
-# * `expl.attribution`: the analyzer's attribution
-# * `expl.output`: the model output
-# * `expl.neuron_selection`: the neuron index used for the attribution
+# * `expl.val`: the numerical output of the analyzer, e.g. an attribution or gradient
+# * `expl.output`: the model output for the given analyzer input
+# * `expl.neuron_selection`: the neuron index used for the explanation
 # * `expl.analyzer`: a symbol corresponding the used analyzer, e.g. `:LRP`
+# * `expl.extras`: an optional named tuple that can be used by analyzers to return additional information.
 
 # Finally, we can visualize the `Explanation` through [`heatmap`](@ref):
 heatmap(expl)
@@ -67,7 +68,7 @@ heatmap(expl)
 heatmap(input, analyzer)
 
 # ## Neuron selection
-# By passing an additional index to our call to [`analyze`](@ref), we can compute the attribution
+# By passing an additional index to our call to [`analyze`](@ref), we can compute an explanation
 # with respect to a specific output neuron.
 # Let's see why the output wasn't interpreted as a 4 (output neuron at index 5)
 heatmap(input, analyzer, 5)

--- a/src/analyze_api.jl
+++ b/src/analyze_api.jl
@@ -11,7 +11,7 @@ const BATCHDIM_MISSING = ArgumentError(
     analyze(input, method)
     analyze(input, method, neuron_selection)
 
-Return an [`Explanation`](@ref) containing the attribution and the raw classifier output.
+Apply the analyzer `method` for the given input, returning an [`Explanation`](@ref).
 If `neuron_selection` is specified, the explanation will be calculated for that neuron.
 Otherwise, the output neuron with the highest activation is automatically chosen.
 
@@ -58,18 +58,18 @@ function _analyze(
 end
 
 """
-Return type of analyzers when calling `analyze`.
+Return type of analyzers when calling [`analyze`](@ref).
 
-Contains:
-* `attribution`: the analyzer's attribution
-* `output`: the model output
-* `neuron_selection`: the neuron index used for the attribution
-* `analyzer`: a symbol corresponding the used analyzer, e.g. `:LRP`
-* `extras`: an optional named tuple that can be used by analyzers
+## Fields
+* `val`: numerical output of the analyzer, e.g. an attribution or gradient
+* `output`: model output for the given analyzer input
+* `neuron_selection`: neuron index used for the explanation
+* `analyzer`: symbol corresponding the used analyzer, e.g. `:LRP` or `:Gradient`
+* `extras`: optional named tuple that can be used by analyzers
     to return additional information.
 """
-struct Explanation{A,O,I,E<:Union{Nothing,NamedTuple}}
-    attribution::A
+struct Explanation{V,O,I,E<:Union{Nothing,NamedTuple}}
+    val::V
     output::O
     neuron_selection::I
     analyzer::Symbol

--- a/src/heatmap.jl
+++ b/src/heatmap.jl
@@ -21,7 +21,7 @@ Assumes Flux's WHCN convention (width, height, color channels, batch size).
     When calling `heatmap` with an array, the default is `ColorSchemes.seismic`.
 - `reduce::Symbol`: How the color channels are reduced to a single number to apply a colorscheme.
     The following methods can be selected, which are then applied over the color channels
-    for each "pixel" in the attribution:
+    for each "pixel" in the explanation:
     - `:sum`: sum up color channels
     - `:norm`: compute 2-norm over the color channels
     - `:maxabs`: compute `maximum(abs, x)` over the color channels in
@@ -49,7 +49,7 @@ function heatmap(
         DomainError(
             N,
             """heatmap assumes Flux's WHCN convention (width, height, color channels, batch size) for the input.
-            Please reshape your attribution to match this format if your model doesn't adhere to this convention.""",
+            Please reshape your explanation to match this format if your model doesn't adhere to this convention.""",
         ),
     )
     if unpack_singleton && size(attr, 4) == 1
@@ -62,7 +62,7 @@ end
 function heatmap(expl::Explanation; permute::Bool=true, kwargs...)
     _cs, _reduce, _rangescale = HEATMAPPING_PRESETS[expl.analyzer]
     return heatmap(
-        expl.attribution;
+        expl.val;
         reduce=get(kwargs, :reduce, _reduce),
         rangescale=get(kwargs, :rangescale, _rangescale),
         cs=get(kwargs, :cs, _cs),
@@ -87,7 +87,7 @@ function _heatmap(
     return ColorSchemes.get(cs, img, rangescale)
 end
 
-# Reduce attributions across color channels into a single scalar – assumes WHCN convention
+# Reduce explanations across color channels into a single scalar – assumes WHCN convention
 function _reduce(attr::AbstractArray{T,3}, method::Symbol) where {T}
     if size(attr, 3) == 1 # nothing to reduce
         return attr

--- a/src/input_augmentation.jl
+++ b/src/input_augmentation.jl
@@ -105,7 +105,7 @@ function (aug::NoiseAugmentation)(input, ns::AbstractNeuronSelector)
 
     # Average explanation
     return Explanation(
-        reduce_augmentation(augmented_expl.attribution, aug.n),
+        reduce_augmentation(augmented_expl.val, aug.n),
         output,
         output_indices,
         augmented_expl.analyzer,
@@ -146,7 +146,7 @@ function (aug::InterpolationAugmentation)(
     augmented_expl = aug.analyzer(augmented_input, AugmentationSelector(augmented_indices))
 
     # Average gradients and compute explanation
-    expl = (input - input_ref) .* reduce_augmentation(augmented_expl.attribution, aug.n)
+    expl = (input - input_ref) .* reduce_augmentation(augmented_expl.val, aug.n)
 
     return Explanation(expl, output, output_indices, augmented_expl.analyzer, nothing)
 end

--- a/test/test_batches.jl
+++ b/test/test_batches.jl
@@ -32,13 +32,13 @@ ANALYZERS = Dict(
 
 for (name, method) in ANALYZERS
     @testset "$name" begin
-        # Using `add_batch_dim=true` should result in same attribution
+        # Using `add_batch_dim=true` should result in same explanation
         # as input reshaped to have a batch dimension
         analyzer = method(model)
         expl1_no_bd = analyzer(input1_no_bd; add_batch_dim=true)
         analyzer = method(model)
         expl1_bd = analyzer(input1_bd)
-        @test expl1_bd.attribution ≈ expl1_no_bd.attribution
+        @test expl1_bd.val ≈ expl1_no_bd.val
 
         # Analyzing a batch should have the same result
         # as analyzing inputs in batch individually
@@ -46,11 +46,11 @@ for (name, method) in ANALYZERS
         expl2_bd = analyzer(input2_bd)
         analyzer = method(model)
         expl_batch = analyzer(input_batch)
-        @test expl1_bd.attribution ≈ expl_batch.attribution[:, 1]
+        @test expl1_bd.val ≈ expl_batch.val[:, 1]
         if !(analyzer isa NoiseAugmentation)
             # NoiseAugmentation methods generate random numbers for the entire batch.
             # therefore explanations don't match except for the first input in the batch.
-            @test expl2_bd.attribution ≈ expl_batch.attribution[:, 2]
+            @test expl2_bd.val ≈ expl_batch.val[:, 2]
         end
     end
 end

--- a/test/test_cnn.jl
+++ b/test/test_cnn.jl
@@ -40,12 +40,12 @@ Flux.testmode!(model, true)
 
 function test_cnn(name, method)
     @testset "$name" begin
-        # Reference test attribution
+        # Reference test explanation
         analyzer = method(model)
         println("Timing $name...")
         print("cold:")
         @time expl = analyze(input, analyzer)
-        attr = expl.attribution
+        attr = expl.val
         @test size(attr) == size(input)
         if name == "LRPZero_COC"
             # Output of Chain of Chains should be equal to flattened model
@@ -59,7 +59,7 @@ function test_cnn(name, method)
         analyzer = method(model)
         print("warm:")
         @time expl2 = analyzer(input)
-        @test expl.attribution ≈ expl2.attribution
+        @test expl.val ≈ expl2.val
 
         # Test direct call of heatmap
         h1 = heatmap(expl)
@@ -77,7 +77,7 @@ function test_cnn(name, method)
         analyzer = method(model)
         neuron_selection = 1
         expl = analyze(input, analyzer, neuron_selection)
-        attr = expl.attribution
+        attr = expl.val
 
         @test size(attr) == size(input)
         if name == "LRPZero_COC"
@@ -92,7 +92,7 @@ function test_cnn(name, method)
         end
         analyzer = method(model)
         expl2 = analyzer(input, neuron_selection)
-        @test expl.attribution ≈ expl2.attribution
+        @test expl.val ≈ expl2.val
     end
 end
 

--- a/test/test_rules.jl
+++ b/test/test_rules.jl
@@ -84,7 +84,7 @@ end
     # Rᵏ₂ = [3/19 8/19]
     # Rᵏ = Rᵏ₁ + Rᵏ₂ = [4/19 8/19]
     e1 = analyze(aᵏ, LRP(model, composite), 1)
-    @test e1.attribution ≈ reshape([4 / 19 8 / 19], 2, 1)
+    @test e1.val ≈ reshape([4 / 19 8 / 19], 2, 1)
 
     # Analogous for output neuron 2:
     # Rᵏ⁺¹ = [0 1]
@@ -99,7 +99,7 @@ end
     # Rᵏ₂ = [5/27 12/27]
     # Rᵏ = Rᵏ₁ + Rᵏ₂ = [5/27 14/27]
     e2 = analyze(aᵏ, LRP(model, composite), 2)
-    @test e2.attribution ≈ reshape([5 / 27 14 / 27], 2, 1)
+    @test e2.val ≈ reshape([5 / 27 14 / 27], 2, 1)
 end
 
 @testset "AlphaBetaRule analytic" begin


### PR DESCRIPTION
since the name was not generic enough for e.g. `Gradient` analyzers.
This also updates docstrings and the documentation.