### PR TITLE
Fix `EpsilonPlusFlat` and `EpsilonAlpha2Beta1Flat` composites

### DIFF
--- a/src/lrp/composite_presets.jl
+++ b/src/lrp/composite_presets.jl
@@ -84,7 +84,7 @@ function EpsilonPlusFlat(; epsilon=1.0f-6)
             ReshapingLayer     => PassRule(),
             typeof(identity)   => PassRule(),
         ),
-        FirstLayerTypeMap(ConvLayer => FlatRule(), Dense => FlatRule()),
+        FirstLayerTypeMap(ConvLayer => FlatRule()),
     )
 end
 
@@ -107,6 +107,6 @@ function EpsilonAlpha2Beta1Flat(; epsilon=1.0f-6)
             ReshapingLayer     => PassRule(),
             typeof(identity)   => PassRule(),
         ),
-        FirstLayerTypeMap(ConvLayer => FlatRule(), Dense => FlatRule()),
+        FirstLayerTypeMap(ConvLayer => FlatRule()),
     )
 end

--- a/test/references/show/EpsilonAlpha2Beta1Flat.txt
+++ b/test/references/show/EpsilonAlpha2Beta1Flat.txt
@@ -16,6 +16,5 @@ Composite(
     Conv          => FlatRule(),
     ConvTranspose => FlatRule(),
     CrossCor      => FlatRule(),
-    Dense         => FlatRule(),
  ),
 )

--- a/test/references/show/EpsilonPlusFlat.txt
+++ b/test/references/show/EpsilonPlusFlat.txt
@@ -16,6 +16,5 @@ Composite(
     Conv          => FlatRule(),
     ConvTranspose => FlatRule(),
     CrossCor      => FlatRule(),
-    Dense         => FlatRule(),
  ),
 )


### PR DESCRIPTION
`FlatRule` should not be applied to fully-connected `Dense` layers, as relevance ends up normalised to $1/n$ over $n$ input neurons, leading to uniform heatmaps.