### PR TITLE
ci(fix): cap `BenchmarkTools` test compat at `~1.6`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,6 @@ jobs:
         version:
           - 'lts'
           - '1'
-          - 'pre'
     steps:
       - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@v3

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -18,4 +18,5 @@ Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [compat]
 Aqua = "0.8"
+BenchmarkTools = "~1.6"
 JET = "0.9, 0.11"


### PR DESCRIPTION
## Why

CI on `main` has been red since late April, for two unrelated reasons:

1. The `Julia lts` and `Julia 1` jobs fail in the `PkgJogger.@test_benchmarks` smoke tests with:

   ```
   MethodError: no method matching var"##sample#..."(::Tuple{...}, ::BenchmarkTools.Parameters)
   → 50 passed, 0 failed, 8 errored
   ```

   `BenchmarkTools` v1.7.0 (released 2026-04-01) changed the signature of its internally generated sample functions (two extra `Ref` arguments for timing and return-value tracking). `PkgJogger` v0.6.0 — its latest release — still calls the old two-argument form in `test_benchmarks` (`src/utils.jl:150`), so every benchmark errors. `test/Project.toml` had no compat bound on `BenchmarkTools`, so CI resolves v1.8.0.

2. The `Julia pre` job fails before tests even start with an unsatisfiable resolver conflict: no `JET` version within the `"0.9, 0.11"` compat bound is installable on prerelease Julia, and `Zygote`'s bound on `LogExpFunctions` conflicts as well.

## Changes

- Add `BenchmarkTools = "~1.6"` to the `[compat]` section of `test/Project.toml` until `PkgJogger` supports the new sample-function signature.
- Remove `pre` from the CI test version matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)